### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 8b37c261810d09af964fd4cf1d2012c3b93994a811d90fd0a2d47e00a3c02400
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     env:
@@ -45,7 +45,7 @@ tests:
         - tests/test_constants.py
     requirements:
       run:
-        - python ${{ python_min }}
+        - python >=${{ python_min }}
         - pip
         - pytest
     script:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -45,7 +45,7 @@ tests:
         - tests/test_constants.py
     requirements:
       run:
-        - python >=${{ python_min }}
+        - python >= ${{ python_min }}
         - pip
         - pytest
     script:


### PR DESCRIPTION
Add explicit range specifier to `python ${{ python_min }}` in run dependencies. The bare form `python 3.10` is ambiguous; use `python >=${{ python_min }}` instead.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
